### PR TITLE
Fix type conversion in shape drawing calculations

### DIFF
--- a/MindFlow.xcodeproj/project.pbxproj
+++ b/MindFlow.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MindFlow/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = MindFlow;
+				INFOPLIST_KEY_CFBundleDisplayName = Mindflow;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -352,7 +352,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MindFlow/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = MindFlow;
+				INFOPLIST_KEY_CFBundleDisplayName = Mindflow;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/MindFlow/Views/Shapes/Shapes.swift
+++ b/MindFlow/Views/Shapes/Shapes.swift
@@ -31,8 +31,8 @@ struct RegularPolygon: Shape {
         for i in 0..<sides {
             let angle = (2.0 * .pi * Double(i)) / Double(sides) - (.pi / 2)
             let point = CGPoint(
-                x: center.x + radius * cos(angle),
-                y: center.y + radius * sin(angle)
+                x: center.x + radius * CGFloat(cos(angle)),
+                y: center.y + radius * CGFloat(sin(angle))
             )
             
             if i == 0 {
@@ -151,8 +151,8 @@ struct Star: Shape {
             let angle = (2.0 * .pi * Double(i)) / Double(points * 2) - (.pi / 2)
             let r = i % 2 == 0 ? radius : innerRadius
             let point = CGPoint(
-                x: center.x + r * cos(angle),
-                y: center.y + r * sin(angle)
+                x: center.x + r * CGFloat(cos(angle)),
+                y: center.y + r * CGFloat(sin(angle))
             )
             
             if i == 0 {


### PR DESCRIPTION
Wrap trigonometric function results with CGFloat in RegularPolygon and Star shapes to ensure type consistency. Also update CFBundleDisplayName in project settings from 'MindFlow' to 'Mindflow'.